### PR TITLE
Added support for method annotations without arguments

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -283,6 +283,10 @@ Parser.prototype.parseAnnotation = function () {
 Parser.prototype.parseMethodArguments = function () {
   var result = [];
   var item;
+  if (this.token === ')') {
+    this.token = this.lexer.lex();
+    return result;
+  }
   do {
     item = this.parseTopStatement();
     if (item !== null) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -320,4 +320,16 @@ describe('Test parser', function () {
       }
     });
   });
+
+  it('test annotation method with no arguments', function () {
+    var ast = doc.parse([
+      '/**',
+      ' * @SomeMethod()',
+      ' * @SomeOtherAnnotation',
+      ' */'
+    ].join('\n'));
+    ast.body.length.should.be.exactly(2);
+    ast.body[0].kind.should.be.exactly('annotation');
+    ast.body[0].arguments.length.should.be.exactly(0);
+  });
 });


### PR DESCRIPTION
Fixed an error where methods annotations with no arguments made the next annotations being parsed as arguments